### PR TITLE
Remove Erroring "Create Comment" from Docusaurus website build

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -76,10 +76,3 @@ jobs:
         echo "machine github.com login $GIT_USERNAME password $GITHUB_TOKEN" > ~/.netrc
         # Run docusaurus-publish
         GIT_USER=$GIT_USERNAME npm run publish-gh-pages --prefix website
-    - name: Create comment
-      if: github.event_name == 'pull_request'
-      uses: peter-evans/create-or-update-comment@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        issue-number: ${{ github.event.number }}
-        body: Website [preview is available](https://${{ github.actor }}.github.io/${{ env.REPO_NAME }})


### PR DESCRIPTION
## Description

This pull request removes `Create comment` from [docusaurus.yml](https://github.com/finos/datahub/blob/master/.github/workflows/docusaurus.yml) which is breaking pull request #39. The PR also brings commit e9c0870 into its own context as the `Create comment` error means #39 will never be merged to apply e9c0870.

### Removed Code

```
    - name: Create comment
      if: github.event_name == 'pull_request'
      uses: peter-evans/create-or-update-comment@v1
      with:
        token: ${{ secrets.GITHUB_TOKEN }}
        issue-number: ${{ github.event.number }}
        body: Website [preview is available](https://${{ github.actor }}.github.io/${{ env.REPO_NAME }})
```