### PR TITLE
Fix minor typos in `delegated-action-groups/datahub-datahelix-collaboration/readme.md`

### DIFF
--- a/docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md
+++ b/docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md
@@ -13,7 +13,7 @@ DataHelix is Java-based, Java is a non-controversial choice well supported and a
 ## Outcome
 
 * [[Link](./outcomes/single-underlying-technology.md)] Single underlying technology
-* [[Link](./outcomes/single-underlying-technology.md)] Support of configuration lanaguage
+* [[Link](./outcomes/single-underlying-technology.md)] Support of configuration language
 
 ## Structure / Skills
 

--- a/docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md
+++ b/docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md
@@ -1,4 +1,4 @@
-# Decision to integrate DataHelx and DataHub
+# Decision to integrate DataHelix and DataHub
 
 __Status:__ Draft
 
@@ -13,7 +13,7 @@ DataHelix is Java-based, Java is a non-controversial choice well supported and a
 ## Outcome
 
 * [[Link](./outcomes/single-underlying-technology.md)] Single underlying technology
-* [[link](./outcomes/single-underlying-technology.md)] Support of configuration lanaguage
+* [[Link](./outcomes/single-underlying-technology.md)] Support of configuration lanaguage
 
 ## Structure / Skills
 


### PR DESCRIPTION
## Description

This PR fixes two minor typos in `docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md` through commit 9d1700c

- `# Decision to integrate DataHelx and DataHub` becomes `# Decision to integrate DataHelix and DataHub`
- `[[link](./outcomes/single-underlying-technology.md)] Support of configuration lanaguage` becomes `[[Link](./outcomes/single-underlying-technology.md)] Support of configuration lanaguage`
- `lanaguage` becomes `language`