### PR TITLE
Add Delegated Action Group and GitHub Issue references to project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ A common question: Now that I have a data frame of synthetic-data, what do I do 
 1. For information on how to get started with DataHub see our [Getting Started Guide](https://github.com/finos/datahub/blob/master/docs/GettingStarted.md)
 2. For more technical information about DataHub and how to customize it, see the [Developer Guide](https://github.com/finos/datahub/blob/master/docs/DeveloperGuide.md)
 3. For high-level project direction see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md) and [Delegated Action Groups](https://github.com/finos/datahub/tree/master/docs/delegated-action-groups).
-4. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
+4. See [DataHub GitHub Issues](https://github.com/finos/datahub/issues) for Feature Development, Good First Issues, Help Wanted and Bug Tracking. 
+5. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
 
 ## Overview of Synthetic data
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A common question: Now that I have a data frame of synthetic-data, what do I do 
 1. For information on how to get started with DataHub see our [Getting Started Guide](https://github.com/finos/datahub/blob/master/docs/GettingStarted.md)
 2. For more technical information about DataHub and how to customize it, see the [Developer Guide](https://github.com/finos/datahub/blob/master/docs/DeveloperGuide.md)
 3. For high-level project direction see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md) and [Delegated Action Groups](https://github.com/finos/datahub/tree/master/docs/delegated-action-groups).
-4. See [DataHub GitHub Issues](https://github.com/finos/datahub/issues) for Feature Development, Good First Issues, Help Wanted and Bug Tracking. 
+4. For Feature Development, Good First Issues, Help Wanted and Bug Tracking see [DataHub GitHub Issues](https://github.com/finos/datahub/issues). 
 5. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
 
 ## Overview of Synthetic data

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A common question: Now that I have a data frame of synthetic-data, what do I do 
 
 1. For information on how to get started with DataHub see our [Getting Started Guide](https://github.com/finos/datahub/blob/master/docs/GettingStarted.md)
 2. For more technical information about DataHub and how to customize it, see the [Developer Guide](https://github.com/finos/datahub/blob/master/docs/DeveloperGuide.md)
-3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md)
+3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Delegated Action Groups](https://github.com/finos/datahub/tree/master/docs/delegated-action-groups) and [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md)
 4. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
 
 ## Overview of Synthetic data

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A common question: Now that I have a data frame of synthetic-data, what do I do 
 
 1. For information on how to get started with DataHub see our [Getting Started Guide](https://github.com/finos/datahub/blob/master/docs/GettingStarted.md)
 2. For more technical information about DataHub and how to customize it, see the [Developer Guide](https://github.com/finos/datahub/blob/master/docs/DeveloperGuide.md)
-3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md)
+3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md)
 4. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
 
 ## Overview of Synthetic data

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A common question: Now that I have a data frame of synthetic-data, what do I do 
 
 1. For information on how to get started with DataHub see our [Getting Started Guide](https://github.com/finos/datahub/blob/master/docs/GettingStarted.md)
 2. For more technical information about DataHub and how to customize it, see the [Developer Guide](https://github.com/finos/datahub/blob/master/docs/DeveloperGuide.md)
-3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Delegated Action Groups](https://github.com/finos/datahub/tree/master/docs/delegated-action-groups) and [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md)
+3. For high-level project direction see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md), [Requirements Gathering Approach](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md) and [Delegated Action Groups](https://github.com/finos/datahub/tree/master/docs/delegated-action-groups).
 4. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
 
 ## Overview of Synthetic data

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A common question: Now that I have a data frame of synthetic-data, what do I do 
 
 1. For information on how to get started with DataHub see our [Getting Started Guide](https://github.com/finos/datahub/blob/master/docs/GettingStarted.md)
 2. For more technical information about DataHub and how to customize it, see the [Developer Guide](https://github.com/finos/datahub/blob/master/docs/DeveloperGuide.md)
-3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/roadmap.md)
+3. For a high-level road map see [Road Map](https://github.com/finos/datahub/blob/master/docs/synthetic-data-roadmap/roadmap.md)
 4. This project uses [Gravizo](https://g.gravizo.com) for all diagrams and charts as highlighted in [DataHub Issue 41](https://github.com/finos/datahub/issues/41).   
 
 ## Overview of Synthetic data

--- a/docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md
+++ b/docs/delegated-action-groups/datahub-datahelix-collaboration/readme.md
@@ -13,7 +13,7 @@ DataHelix is Java-based, Java is a non-controversial choice well supported and a
 ## Outcome
 
 * [[Link](./outcomes/single-underlying-technology.md)] Single underlying technology
-* [[Link](./outcomes/single-underlying-technology.md)] Support of configuration language
+* [[Link](./outcomes/support-of-config-language.md)] Support of configuration language
 
 ## Structure / Skills
 

--- a/docs/delegated-action-groups/readme.md
+++ b/docs/delegated-action-groups/readme.md
@@ -57,11 +57,12 @@ Describe the problem in 2/3 paragraphs
 
 ## Structure / Skills
 
-- [Chair] - <name>- [Data Science]
-- Fred Morris- [Big Data Export]
-- Someone Else- [Stakeholder 1]
-- A.Stakeholder- [Stakeholder 2]
-- B.Stakeholder- [Stakeholder 3] - C.Stakeholder
+- [Chair] - <name> - [Data Science]
+- Fred Morris - [Big Data Export]
+- Someone Else - [Stakeholder 1]
+- A.Stakeholder - [Stakeholder 2]
+- B.Stakeholder - [Stakeholder 3] 
+- C.Stakeholder - [Stakeholder 3] 
 
 ## Timelines and Constraints
 

--- a/docs/delegated-action-groups/synthetic-data-architecture/readme.md
+++ b/docs/delegated-action-groups/synthetic-data-architecture/readme.md
@@ -9,7 +9,7 @@ Synthetic data is a complex subject with many approaches and moving parts, to sc
 ## Outcomes
 
 * [[Link](./outcomes/single-underlying-technology.md)] Declare a typical synthetic-data pipeline process
-* [[link](./outcomes/specification-standards.md)] Declare modules and specification standards
+* [[Link](./outcomes/specification-standards.md)] Declare modules and specification standards
 
 ## Structure / Skills
 

--- a/docs/delegated-action-groups/synthetic-data-architecture/readme.md
+++ b/docs/delegated-action-groups/synthetic-data-architecture/readme.md
@@ -8,7 +8,7 @@ Synthetic data is a complex subject with many approaches and moving parts, to sc
 
 ## Outcomes
 
-* [[Link](./outcomes/single-underlying-technology.md)] Declare a typical synthetic-data pipeline process
+* [[Link](./outcomes/standard-pipeline-process.md)] Declare a typical synthetic-data pipeline process
 * [[Link](./outcomes/specification-standards.md)] Declare modules and specification standards
 
 ## Structure / Skills

--- a/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md
+++ b/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md
@@ -17,3 +17,7 @@ The following items describe the steps needed to gather the Synthetic Data requi
 4. Contact FINOS project teams and understand their Synthetic Data requirements. The first project being [Morphir](https://github.com/finos/morphir) and then [Alloy](https://github.com/finos/alloy).
 
 5. Direct / Influence DataHub and DataHelix roadmap based on input from the team.
+
+### Delegated Action Groups and GitHub Issues
+
+The outcomes of the requirements gathering exercise can be found in the [Delegated Action Groups](https://github.com/finos/datahub/tree/master/docs/delegated-action-groups) and [DataHub GitHub Issues](https://github.com/finos/datahub/issues).

--- a/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md
+++ b/docs/synthetic-data-roadmap/synthetic-data-requirements-gathering.md
@@ -1,5 +1,11 @@
 # Synthetic Data Approach for Gathering Requirements
 
+The following diagram was presented to the FINOS community on 10th September 2020 and outlines the requirements gathering approach below.
+
+<img src="images/synthetic-data-requirements-gathering.png" width="650" />
+
+### Requirements Gathering Approach
+
 The following items describe the steps needed to gather the Synthetic Data requirements for DataHub and DataHelix.
 
 1. Synthetic Data Requirements Obtained and Available in DataHub GitHub
@@ -11,9 +17,3 @@ The following items describe the steps needed to gather the Synthetic Data requi
 4. Contact FINOS project teams and understand their Synthetic Data requirements. The first project being [Morphir](https://github.com/finos/morphir) and then [Alloy](https://github.com/finos/alloy).
 
 5. Direct / Influence DataHub and DataHelix roadmap based on input from the team.
-
-### Diagram Outlining Synthetic Data Team Approach
-
-The following diagram was presented to the FINOS community on 10th September 2020 and outlines the approach taken above.
-
-<img src="images/synthetic-data-requirements-gathering.png" width="650" />


### PR DESCRIPTION
## Description

This pull request adds references to Delegated Action Groups and GitHub Issues to DataHub project documentation through the commits listed below. 

- update roadmap url in readme 30deb3d
- move requirements gathering image in requirements gathering doc 57d354b
- add requirements gathering approach link to readme 219e192
- add delegated action groups link to readme 336900c
- add delegated action groups and github issues links to requirements dbdc748
- updated roadmap order in readme 308c395
- add github issues to project readme 66e053a
- add github issues to project readme c8d1d95
- update c.stakeholder format 9390982
- update link capitalization 2684633
- update standard-pipeline-process link 217b9f4
- update support-of-config-language link 5945bad